### PR TITLE
translated part 1.2 'Types and Functions'

### DIFF
--- a/src/main/tut/types-and-functions.md
+++ b/src/main/tut/types-and-functions.md
@@ -1,0 +1,84 @@
+```Haskell
+x :: Integer
+```
+```scala
+val x: BigInt
+```
+................
+```Haskell
+f :: Bool -> Bool
+```
+```scala
+val f: Boolean => Boolean
+```
+................
+```Haskell
+f :: Bool -> Bool
+f x = undefined
+```
+```scala
+val f: Boolean => Boolean = x => ???
+```
+................
+```Haskell
+f :: Bool -> Bool
+f = undefined
+```
+```scala
+def f: Boolean => Boolean = ???
+```
+................
+```Haskell
+fact n = product [1..n]
+```
+```scala
+val fact = (n: Int) => (1 to n toList) product
+```
+................
+```Haskell
+absurd :: Void -> a
+```
+```scala
+def absurd[A]: Nothing => A
+```
+................
+```Haskell
+f44 :: () -> Integer
+f44 () = 44
+```
+```scala
+val f44: Unit => BigInt = _ => 44
+```
+................
+```Haskell
+fInt :: Integer -> ()
+fInt x = ()
+```
+```scala
+val fInt: BigInt => Unit = x => ()
+```
+................
+```Haskell
+fInt :: Integer -> ()
+fInt _ = ()
+```
+```scala
+val fInt: BigInt => Unit = _ => ()
+```
+................
+```Haskell
+unit :: a -> ()
+unit _ = ()
+```
+```scala
+def unit[A]: A => Unit = _ => ()
+```
+................
+```Haskell
+data Bool = True | False
+```
+```scala
+sealed trait Bool
+case object True extends Bool
+case object False extends Bool
+```

--- a/src/main/tut/types-and-functions.md
+++ b/src/main/tut/types-and-functions.md
@@ -16,7 +16,7 @@ val f: Boolean => Boolean
 f :: Bool -> Bool
 f x = undefined
 ```
-```scala
+```tut:silent
 val f: Boolean => Boolean = x => ???
 ```
 ................
@@ -24,14 +24,14 @@ val f: Boolean => Boolean = x => ???
 f :: Bool -> Bool
 f = undefined
 ```
-```scala
+```tut:silent
 def f: Boolean => Boolean = ???
 ```
 ................
 ```Haskell
 fact n = product [1..n]
 ```
-```scala
+```tut:silent
 val fact = (n: Int) => (1 to n).toList.product
 ```
 ................
@@ -46,7 +46,7 @@ def absurd[A]: Nothing => A
 f44 :: () -> Integer
 f44 () = 44
 ```
-```scala
+```tut:silent
 val f44: Unit => BigInt = _ => 44
 ```
 ................
@@ -54,7 +54,7 @@ val f44: Unit => BigInt = _ => 44
 fInt :: Integer -> ()
 fInt x = ()
 ```
-```scala
+```tut:silent
 val fInt: BigInt => Unit = x => ()
 ```
 ................
@@ -62,7 +62,7 @@ val fInt: BigInt => Unit = x => ()
 fInt :: Integer -> ()
 fInt _ = ()
 ```
-```scala
+```tut:silent
 val fInt: BigInt => Unit = _ => ()
 ```
 ................
@@ -70,14 +70,14 @@ val fInt: BigInt => Unit = _ => ()
 unit :: a -> ()
 unit _ = ()
 ```
-```scala
+```tut:silent
 def unit[A]: A => Unit = _ => ()
 ```
 ................
 ```Haskell
 data Bool = True | False
 ```
-```scala
+```tut:silent
 sealed trait Bool
 case object True extends Bool
 case object False extends Bool

--- a/src/main/tut/types-and-functions.md
+++ b/src/main/tut/types-and-functions.md
@@ -32,7 +32,7 @@ def f: Boolean => Boolean = ???
 fact n = product [1..n]
 ```
 ```scala
-val fact = (n: Int) => (1 to n toList) product
+val fact = (n: Int) => (1 to n).toList.product
 ```
 ................
 ```Haskell


### PR DESCRIPTION
I tried to follow similar conventions as in `category-the-essence-of-composition.md`, but there are a bunch of different ways to translate the Haskell code snippets to Scala, so it'd be nice if we could make a short style guide or something to keep things consistent

**ex 1** `val fact = (n: Int) => (1 to n toList) product` vs. `val fact = (n: Int) => (1 to n).toList.product` vs. `val fact = (n: Int) => List.range(1, n).product` vs. `def fact(n: Int) = (1 to n).toList.product` etc.


**ex 2**
```Haskell
fInt :: Integer -> ()
fInt x = ()
```
```scala
val fInt: BigInt => Unit = x => ()
```
................
```Haskell
fInt :: Integer -> ()
fInt _ = ()
```
```scala
val fInt: BigInt => Unit = _ => ()
```
vs
```Haskell
fInt :: Integer -> ()
fInt x = ()

fInt _ = ()
```
```scala
val fInt: BigInt => Unit = x => ()

val fInt: BigInt => Unit = _ => ()
```