### PR TITLE
Use wildcard pattern matching in Scala example

### DIFF
--- a/src/main/tut/1.5-products-and-coproducts.md
+++ b/src/main/tut/1.5-products-and-coproducts.md
@@ -63,9 +63,12 @@ fst (x, _) = x
 snd (_, y) = y
 ```
 ```tut:silent
-def fst[A, B]: ((A, B)) => A = _._1
-
-def snd[A, B]: ((A, B)) => B = _._2
+def fst[A, B]: ((A, B)) => A = {
+  case (x, _) => x
+}
+def snd[A, B]: ((A, B)) => B = {
+  case (_, y) => y
+}
 ```
 ................
 ```Haskell


### PR DESCRIPTION
The edited Scala snippets are currently not equivalent to the Haskell examples' use of wildcards in pattern matching; this PR replaces them with ones that are.